### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# permissions:
-#   contents: read
+permissions:
+  contents: read
 
 env:
   CI: true


### PR DESCRIPTION
Potential fix for [https://github.com/lewismorgan/lewis/security/code-scanning/5](https://github.com/lewismorgan/lewis/security/code-scanning/5)

To fix this, explicitly declare limited `permissions` for the workflow so that the automatically provided `GITHUB_TOKEN` is restricted to read-only access to repository contents (and anything else minimally required). Because all jobs only need to read code and upload artifacts (which doesn’t require repo write access), the minimal safe and accurate scope is `contents: read` at the workflow root.

The best fix without changing functionality is:

- Uncomment and slightly adjust the existing commented-out permissions block near the top of `.github/workflows/ci.yml`.
- Set `permissions:` at the workflow root (same level as `on:` and `concurrency:`), with `contents: read`. This will apply to all jobs that don’t override it, which is what we want, and will satisfy CodeQL’s recommendation.

Concretely:

- In `.github/workflows/ci.yml`, around lines 14–16, replace the commented-out permissions block (`# permissions: ...`) with an active one:
  - Add `permissions:` on its own line.
  - Under it, add `contents: read` indented two spaces.
- No imports or additional methods are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
